### PR TITLE
채팅목록, 채팅내용 split 및 물품 상세보기 refactoring

### DIFF
--- a/bill2_react/src/chat/chat.css
+++ b/bill2_react/src/chat/chat.css
@@ -1,3 +1,4 @@
+
 .chatPageMain {
     width: 100%;
     height: 100%;
@@ -28,12 +29,13 @@
 }
 .chatCard {
     height: 15%;
+    width: 100%;
 }
 .date {
     float: right;
     position: relative;
-    top: -30px;
     font-weight: lighter;
+    bottom : 20px;
 }
 .receiveMessage {
     display: inline-block;
@@ -78,6 +80,12 @@
     margin-left: 25px;
     margin-right: 25px;
 }
+.dateBox {
+    display: flex;
+    justify-content: center;
+    margin-bottom: 10%;
+    background-color: #e1f4fd;
+}
 .chatSendButton {
     position: fixed;
     bottom: 0; left: 82%;
@@ -114,17 +122,3 @@
     justify-content: center;
     font-weight: bold;
 }
-
-
-
-
-/*.backTopButton {*/
-/*    height: 25px;*/
-/*    width: 100px;*/
-/*    lineHeight: 40px;*/
-/*    border-radius: 5px 5px 5px 5px;*/
-/*    background-color: #1bcfdc;*/
-/*    color: #ffffff;*/
-/*    textAlign: center;*/
-/*    fontSize: 14;*/
-/*}*/

--- a/bill2_react/src/productViewDetails/productViewDetails.js
+++ b/bill2_react/src/productViewDetails/productViewDetails.js
@@ -98,14 +98,7 @@ function ProductViewDetailsPage () {
     const handleProductCancel = () => {
         setIsProductModalVisible(false);    //수정부분
         setUserProduct([]);    //수정부분
-
     };
-
-    const handleProductCancel = () => {
-        setIsProductModalVisible(false);    //수정부분
-        setUserProduct([]);    //수정부분
-    };
-
 
 
 
@@ -157,24 +150,7 @@ function ProductViewDetailsPage () {
 
 
 
-    const toProductViewDetailsPage = (itemId) => {     //수정부분
-        console.log(itemId)    //수정부분
-        setItemId(itemId);     //수정부분
-        handleProductCancel();    //수정부분
-
-
-    }
-
-    const onClickChatButton = () => {navigate("/chat")}   //꼭 안에 감싸기     //수정부분
-
-
-
-
-
-
-
     // const navigate = useNavigate();
-
 
 
     function ItemProduct (){


### PR DESCRIPTION
1. 채팅목록 마지막 채팅 내용 및 시간이 뜨도록 구현완료 했습니다.

2. 초반에 채팅하기 들어가면 채팅목록은 뜨고 채팅화면은 아무것도 안뜨도록 구현했습니다.
채팅목록에서 클릭을 하면 오른쪽에 해당 판매자와의 채팅방이 나오도록 구현했습니다.
채팅방에 입장하면 윗쪽에 해당 물품이 나오도록 구현했습니다.
*** chat 목록 API에서 itemId가 주어지지 않아 시연 시 제대로 나오지 않습니다.  이 부분은 한민님께 요청하겠습니다.
채팅방에서 채팅내용을 수신자(회색), 발신자(파란색)로 나눠서 보여주도록 구현했습니다.
채팅 내용 아래에 해당 채팅 내용 시간이 나오도록 구현했습니다.
채팅 내용을 날짜별로 나누었고 날짜에 색을 넣어 보기 쉽게 구분선을 구현했습니다.

3. 물품 상세보기 저번 pr때 오류가 생긴 것 같아 다시 pr했습니다.

